### PR TITLE
Correction to Nexus M2Settings Maven Plugin example

### DIFF
--- a/chapter-maven-settings.asciidoc
+++ b/chapter-maven-settings.asciidoc
@@ -173,7 +173,7 @@ initially have to use a fully qualified groupId and artifactId in
 addition to the goal. An example invocation of the +download+ goal is:
 
 ----
-mvn org.sonatype.plugins:nexus-m2-settings-maven-plugin:download
+mvn org.sonatype.plugins:nexus-m2settings-maven-plugin:download
 ----
 
 In order to be able to use an invocation with the simple plugin prefix


### PR DESCRIPTION
I noticed a slight error in the first example of a Nexus M2Settings Maven Plugin invocation of the download goal. There was a dash between "m2-settings" where it should be "m2settings" like the rest of the references. 

Hopefully this helps,

Justin
