### PR TITLE
Suggested strike+

### DIFF
--- a/chapter-configuration.asciidoc
+++ b/chapter-configuration.asciidoc
@@ -1628,7 +1628,7 @@ implicit capture in the Staging Suite as documented in <<staging>>.
 [[security-roles]]
 === Managing Roles
 
-Nexus ships with a large number of predefined including 'Nexus
+Nexus ships with a large number of roles predefined including 'Nexus
 Administrator Role', 'Nexus Anonymous Role', 'Nexus Developer Role',
 and 'Nexus Deployment Role'.  Click on the 'Roles' menu item under
 'Security' in the 'Nexus' menu to show the list of roles shown in

--- a/chapter-configuration.asciidoc
+++ b/chapter-configuration.asciidoc
@@ -1616,7 +1616,7 @@ establish a fine-grained control of artifacts included and excluded.
 
 Once you have created a repository target, you can utilize it as part of your
 security setup.  You can add a new privilege that relates to the
-target and controls the CRUD operations for artifacts matching that
+target and controls the CRUD (Create, Read, Update and Delete) operations for artifacts matching that
 path. The privilege can even span multiple repositories. With this
 setup you can delegate all control of artifacts in 'org.apache.maven'
 to a "Maven" team. In this way, you don't need to create separate

--- a/chapter-configuration.asciidoc
+++ b/chapter-configuration.asciidoc
@@ -1533,7 +1533,7 @@ users, you use roles to make it easier to manage users with similar
 sets of privileges. A role has one or more privileges and/or one or
 more roles.
 
-Users:: Users can be assigned roles and model the
+Users:: Users can be assigned roles and will model the
 individuals who will be logging into Nexus and reading, deploying, or
 managing repositories.
 

--- a/chapter-configuration.asciidoc
+++ b/chapter-configuration.asciidoc
@@ -1691,7 +1691,7 @@ has read-only privileges, and the deployment user can both read and
 deploy to repositories. If you need to create users with a more
 focused set of permissions, you can click on 'Users' under 'Security'
 in the left-hand 'Nexus' menu. Once you see the list of users, you can
-click on a user to edit that specific user's 'User ID', 'First Name',
+click on a user to edit that specific user's 'First Name',
 'Last Name' and 'Email'. Editing a users 'Status' allows you to
 activate or disable a user altogether. You can also assign or revoke
 specific roles for a particular user.

--- a/chapter-configuration.asciidoc
+++ b/chapter-configuration.asciidoc
@@ -1614,7 +1614,7 @@ image::figs/web/repository-manager_repository-targets-2.png[scale=60]
 By combining multiple patterns in a repository target, you can
 establish a fine-grained control of artifacts included and excluded.
 
-Once you have created a repository target, you can it as part of your
+Once you have created a repository target, you can utilize it as part of your
 security setup.  You can add a new privilege that relates to the
 target and controls the CRUD operations for artifacts matching that
 path. The privilege can even span multiple repositories. With this

--- a/chapter-configuration.asciidoc
+++ b/chapter-configuration.asciidoc
@@ -1533,7 +1533,7 @@ users, you use roles to make it easier to manage users with similar
 sets of privileges. A role has one or more privileges and/or one or
 more roles.
 
-Users:: Users can be assigned roles and privileges, and model the
+Users:: Users can be assigned roles and model the
 individuals who will be logging into Nexus and reading, deploying, or
 managing repositories.
 


### PR DESCRIPTION
The testguide specifically says you cannot assign privileges to users, that you have to assign the privilidges to a role which then you can assign to a user.  My test of this showed this to be true.  While just a wording difference, I think not having privilege lessens the chance of confusion and IMO is better than the alternative which would be to explain this verbosely.