### PR TITLE
Version font consistancy

### DIFF
--- a/chapter-yum.asciidoc
+++ b/chapter-yum.asciidoc
@@ -106,7 +106,7 @@ specific versions. For example, you can configure alias values of
 production=1.2,testing=2.0
 ----
 
-These values would in turn expose the version +1.2+ under a URL like
+These values would in turn expose the version 1.2 under a URL like
 +http://localhost:8081/nexus/service/local/yum/repos/releases/production/+
 and the version 2.0 at
 +http://localhost:8081/nexus/service/local/yum/repos/releases/testing/+. Using


### PR DESCRIPTION
I noticed that version 1.2 had ++ markup and version 2.0 does not.  I removed the markup but am doing a PR.  If you disagree, please consider then adding it to 2.0 and making this consistent the reverse way.