### PR TITLE
Remove reference to location

### DIFF
--- a/chapter-smartproxy.asciidoc
+++ b/chapter-smartproxy.asciidoc
@@ -127,7 +127,7 @@ or usage of external keys is necessary.
 [[smartproxy-repository_specific_smart_proxy_configuration]]
 === Repository Specific Smart Proxy Configuration
 
-Once Smart Proxy has been configured and enabled as described above,
+Once Smart Proxy has been configured and enabled as previously described,
 you have to configure which repositories contents should be
 proxied more efficiently between the servers. This is done in the 'Repositories'
 administration interface in a separate configuration tab titled 'Smart


### PR DESCRIPTION
I know we've talked about this and believe the conclusion was that locational references need to be paper/web unspecific which I do not believe the word "above" is.  I've genericized but since unsure making a PR.