### PR TITLE
Remove redundant letter

### DIFF
--- a/chapter-maven.asciidoc
+++ b/chapter-maven.asciidoc
@@ -10,7 +10,7 @@ formats now, the Maven repository format is still the most common and
 well supported format for build and provisioning tools running on the
 JVM and beyond. 
 
-This chapter shows example configurations for using Nexus with a Maven
+This chapter shows example configurations for using Nexus with Maven
 and number of other tools. The setups take advantage of Nexus merging
 many repositories and exposing them via a repository group. Setting
 this up is documented in the chapter in addition to the configuration

--- a/chapter-maven.asciidoc
+++ b/chapter-maven.asciidoc
@@ -11,7 +11,7 @@ well supported format for build and provisioning tools running on the
 JVM and beyond. 
 
 This chapter shows example configurations for using Nexus with Maven
-and number of other tools. The setups take advantage of Nexus merging
+and a number of other tools. The setups take advantage of Nexus merging
 many repositories and exposing them via a repository group. Setting
 this up is documented in the chapter in addition to the configuration
 used by specific tools.


### PR DESCRIPTION
I believe either the letter a is redundant or there is a word missing.  Sending PR to assure I'm right and I picked the right fix.
I noticed this reviewing the NX3 book draft btw.