### PR TITLE
Rewrite based on NEXUS-9374 decision

### DIFF
--- a/chapter-docker.asciidoc
+++ b/chapter-docker.asciidoc
@@ -190,6 +190,10 @@ authentication is persisted in `~/.docker/config.json` and reused for any subseq
 repository.  Individual login operations must be performed for each repository and repository group you want to
 access in an authenticated manner.
 
+TIP: Specifically when planning to push to a repository a pre-emptive login operation is advisable as it removes
+the need for use interaction and is therefore suitable for continuous integration server setups and the
+automations scenarios.
+
 === Accessing Docker Repositories
 
 You can browse Docker repositories in the Nexus user interface and inspect the components and assets and their

--- a/chapter-docker.asciidoc
+++ b/chapter-docker.asciidoc
@@ -173,16 +173,22 @@ TIP: Check out this repository configuration demonstrated in link:https://www.yo
 
 === Authentication
 
-Before performing any command against a Nexus Docker hosted or proxy repository, you must perform a docker login 
-command such as follows:
+If access to a repository requires the user to be authenticated, `docker` queries the user for the username,
+password and email address and persists it in `~/.docker/config.json`.  Typically this is required when
+<<anonymous, anonymous access>> to the repository manager is disabled or the operation requires authentication. An
+example is a `push` operation that publishes an image to the repository.
+
+The authentication can be configured in a separate step using the `docker login` command for the desired
+repository or repository group:
 
 ----
 docker login <nexus-hostname>:<repository-port>
 ----
 
-Provide a Nexus username and password as well as an email address. This authentication is persisted in 
-`~/.docker/config.json` and reused for any subsequent interactions against that repository.  Individual logins 
-must be performed for each hosted and proxy repository.
+Provide your repository manager credentials of username and password as well as an email address. This
+authentication is persisted in `~/.docker/config.json` and reused for any subsequent interactions against that
+repository.  Individual login operations must be performed for each repository and repository group you want to
+access in an authenticated manner.
 
 === Accessing Docker Repositories
 

--- a/chapter-docker.asciidoc
+++ b/chapter-docker.asciidoc
@@ -173,9 +173,16 @@ TIP: Check out this repository configuration demonstrated in link:https://www.yo
 
 === Authentication
 
-The first invocation of any command against a Nexus Docker connector and therefore a Docker repository or repository
-group triggers a login request. Provide the Nexus username and password as well as an email address to Docker. This
-authentication is persisted in `~/.docker/config.json` and reused for any subsequent interaction.
+Before performing any command against a Nexus Docker hosted or proxy repository, you must perform a docker login 
+command such as follows:
+
+----
+docker login <nexus-hostname>:<repository-port>
+----
+
+Provide a Nexus username and password as well as an email address. This authentication is persisted in 
+`~/.docker/config.json` and reused for any subsequent interactions against that repository.  Individual logins 
+must be performed for each hosted and proxy repository.
 
 === Accessing Docker Repositories
 


### PR DESCRIPTION
In m6 you need to login before you can perform any actions against hosted/proxy repositories.  This invalidates the docker authentication section as written as you are no longer prompted (NEXUS-9374).
Creating a PR rather than committing directly since a larger revamp.

This section was also adjusted to "size 114" tho probably don't notice since almost totally rewritten.