### PR TITLE
fix hidden anchor link titles

### DIFF
--- a/site/css/clmBook.css
+++ b/site/css/clmBook.css
@@ -266,6 +266,15 @@ div.content + div.title {
 .header-centered {
     text-align: center;
 }
+/* align anchored links to below the fixed navbar */
+*[id]:before {
+  display: block;
+  content: " ";
+  margin-top: -55px;
+  height: 55px;
+  visibility: hidden;
+}
+
 
 /* --- Sub Nav Styling --- */
 


### PR DESCRIPTION
An example url:

http://books.sonatype.com/nexus-book/3.0/reference/security.html#ssl-inbound

Before:

![image](https://cloud.githubusercontent.com/assets/193901/11728005/bf52f244-9f5d-11e5-944e-86a46495a724.png)

After:

![image](https://cloud.githubusercontent.com/assets/193901/11727989/a1890d98-9f5d-11e5-8caa-56d62cd6c9ed.png)
