### PR TITLE
[OSSRH-1992] Change credentials to static string to avoid breaking clients

### DIFF
--- a/chapter-maven.asciidoc
+++ b/chapter-maven.asciidoc
@@ -465,12 +465,13 @@ These minimal settings allow sbt to download the declared dependencies.
 To deploy build outputs to a Nexus repository with the +publish+
 task, user credentials can be declared in the +build.sbt+ file:
 
-// The credentials string should never change, as third-party clients depend on it
 [subs="attributes"]
 ----
 credentials += Credentials("Sonatype Nexus Repository Manager",
 "nexus.scala-tools.org", "admin", "admin123")
 ----
+
+TIP: The credentials string should never change, as third-party clients depend on it
 
 and then used in the +publishTo+ configuration:
 

--- a/chapter-maven.asciidoc
+++ b/chapter-maven.asciidoc
@@ -467,6 +467,7 @@ task, user credentials can be declared in the +build.sbt+ file:
 
 [subs="attributes"]
 ----
+// This string should never change, regardless of branding, as third-party clients depend on it
 credentials += Credentials("Sonatype Nexus Repository Manager",
 "nexus.scala-tools.org", "admin", "admin123")
 ----

--- a/chapter-maven.asciidoc
+++ b/chapter-maven.asciidoc
@@ -473,7 +473,7 @@ credentials += Credentials("Sonatype Nexus Repository Manager",
 
 TIP: The credentials string should never change, as third-party clients depend on it
 
-and then used in the +publishTo+ configuration:
+And then used in the +publishTo+ configuration:
 
 ----
 publishTo <<= version { v: String =>

--- a/chapter-maven.asciidoc
+++ b/chapter-maven.asciidoc
@@ -467,7 +467,7 @@ task, user credentials can be declared in the +build.sbt+ file:
 
 [subs="attributes"]
 ----
-credentials += Credentials("{pro}",
+credentials += Credentials("Sonatype Nexus Repository Manager",
 "nexus.scala-tools.org", "admin", "admin123")
 ----
 

--- a/chapter-maven.asciidoc
+++ b/chapter-maven.asciidoc
@@ -465,9 +465,9 @@ These minimal settings allow sbt to download the declared dependencies.
 To deploy build outputs to a Nexus repository with the +publish+
 task, user credentials can be declared in the +build.sbt+ file:
 
+// The credentials string should never change, as third-party clients depend on it
 [subs="attributes"]
 ----
-// This string should never change, regardless of branding, as third-party clients depend on it
 credentials += Credentials("Sonatype Nexus Repository Manager",
 "nexus.scala-tools.org", "admin", "admin123")
 ----


### PR DESCRIPTION
Issue: https://issues.sonatype.org/browse/OSSRH-19926

Related: https://github.com/sonatype/nexus-book/pull/119

This string should never change, regardless of branding, as third-party clients depend on it. As a result, I’ve changed it from the {pro} macro to a static string.