### PR TITLE
Fixes typo described in #144

### DIFF
--- a/chapter-nuget.asciidoc
+++ b/chapter-nuget.asciidoc
@@ -141,7 +141,7 @@ new 'Repository Group' with the 'Provider' set to +NuGet+ as documented in <<rep
 A typical, useful example would be to group the proxy repository that
 proxies the NuGet Gallery, a NuGet, hosted repository with internal
 software packages and another NuGet, hosted repository with third-party
-packages.. The configuration for such a setup is displayed in
+packages. The configuration for such a setup is displayed in
 <<fig-nuget-group>>.
 
 [[fig-nuget-group]]


### PR DESCRIPTION
Remove double dot from sentence: 

`A typical, useful example would be to group the proxy repository that proxies the NuGet Gallery, a NuGet, hosted repository with internal software packages and another NuGet, hosted repository with third-party packages..`