### PR TITLE
Docker chapter improvements

### DIFF
--- a/chapter-docker.asciidoc
+++ b/chapter-docker.asciidoc
@@ -17,8 +17,8 @@ more and more other publicly available registries such as the https://cloud.goog
 Container Registry] and others.
 
 {pro} and {oss} support Docker registries as the Docker repository format for hosted and proxy repositories. You
-can then expose these repositories to the client-side tools directly or as a repository group, which is a
-repository that merges and exposes the contents of multiple repositories in one convenient URL.
+can expose these repositories to the client-side tools directly or as a repository group, which is a repository 
+that merges and exposes the contents of multiple repositories in one convenient URL.
 
 This allows you to reduce time and bandwidth usage for accessing Docker images in a registry as well as share your
 images within your organization in a hosted repository. Users can then launch containers based on those images,
@@ -90,7 +90,7 @@ utlilty.
 === Support for Docker Registry API
 
 The Docker client tools interact with a repository via the registry API. It is available in version 1 (V1) and
-version 2 (V2). The newer V2 will completely replace the old V1 in the future. Currently DockerHub and other
+version 2 (V2). The newer V2 will completely replace the old V1 in the future. Currently Docker Hub and other
 registries as well as other tools use V2, but in many cases fall back to V1. E.g., search is currently only
 implemented in V1.
 
@@ -98,8 +98,9 @@ implemented in V1.
 configure 'Docker Registry API Support'. If you activate 'Enable Docker V1 API' for a repository it is enabled to
 use V1 as a fallback from V2. Without this option any V1 requests result in errors from the client tool.
 
-TIP: We suggest to *only* activate V1 support for repository groups that will be used for command line-based
-searches, when any client side tools in use require V1 or when a upstream proxy repository requires V1.
+TIP: Generally V1 support is only needed for repository groups that will be used for command line-based searches, 
+when any client side tools in use require V1 or when a upstream proxy repository requires V1.  If you are unsure 
+if your setup uses these or V1, we recommend activating V1 support as there should be no harm if it is not needed.
 
 [[docker-proxy]]
 === Proxy Repository for Docker
@@ -116,7 +117,7 @@ Minimal configuration steps are:
 - Define 'Name'
 - Define URL for 'Remote storage'
 - 'Enable Docker V1 API' support, if required by the remote repository
-- Select correct 'Docker index' and configure it
+- Select correct 'Docker index', further configure 'Location of Docker index' if needed
 - Select 'Blob store' for 'Storage'
 
 Optionally you can configure 'Repository Connectors' as explained in <<docker-ssl-connector>>, although typically 
@@ -144,7 +145,7 @@ It is important to configure a correct pair of 'Remote Storage' URL and 'Docker 
 search results potentially do not reflect the content of the remote repository and other problems can occur.
 
 TIP: Just to recap, in order to configure a proxy for Docker Hub you configure the 'Remote Storage' URL to
-https://registry-1.docker.io, enable Docker V1 API support and for the choice of 'Docker Index' select the 'User
+https://registry-1.docker.io, enable Docker V1 API support and for the choice of 'Docker Index' select the 'Use 
 Docker Hub' option.
 
 [[docker-hosted]]
@@ -198,13 +199,13 @@ video].
 
 === Authentication
 
-If access to a repository requires the user to be authenticated, `docker` queries the user for the username,
-password and email address and persists it in `~/.docker/config.json`.  Typically this is required when
-<<anonymous, anonymous access>> to the repository manager is disabled or the operation requires authentication. An
-example is a `push` operation that publishes an image to the repository.
+If access to a repository requires the user to be authenticated, `docker` will check for authentication access in
+the `~/.docker/config.json` file.  If authentication is not found, some actions will prompt for authentication but 
+otherwise a `docker login` command will be required before the actions can be performed. Typically this is 
+required when <<anonymous, anonymous access>> to the repository manager is disabled or the operation requires 
+authentication.
 
-The authentication can be configured in a separate step using the `docker login` command for the desired
-repository or repository group:
+The `docker login` command observes the following syntax for the desired repository or repository group:
 
 ----
 docker login <nexus-hostname>:<repository-port>
@@ -216,8 +217,8 @@ repository.  Individual login operations must be performed for each repository a
 access in an authenticated manner.
 
 TIP: Specifically when planning to push to a repository a preemptive login operation is advisable as it removes
-the need for use interaction and is therefore suitable for continuous integration server setups and the
-automations scenarios.
+the need for use interaction and is therefore suitable for continuous integration server setups and autonomous 
+scenarios.
 
 ////
 === Configuration
@@ -245,7 +246,8 @@ with
 command:: a docker command such as 'push' or 'pull'
 nexus-hostname:: the IP number or hostname of your repository manager
 repository-port:: the port configured as the repository connector for the specific repository or repository group
-namespace:: the namespace of the specific image reflecting the owner
+namespace:: the optional namespace of the specific image reflecting the owner, if left out this will silently 
+default to '/library' and utilize Docker Hub
 image:: the name of the Docker image
 tag:: the optional tag of the image, defaulting to 'latest' when omitted
 search-term:: the search term or name of the image to search for
@@ -299,7 +301,7 @@ The preferred setup is to proxy all relevant sources of public/private images yo
 being the most common choice. Then configure one or more hosted repositories to contain your own images, and
 expose these repositories through one repository group.
 
-Examples for various images from {oss} running on the host `nexus.example.com` and exposing a repository
+Examples for various images from {pro} running on the host `nexus.example.com` and exposing a repository
 group with a repository connector port of 18443 are:
 
 ----
@@ -317,13 +319,13 @@ After a successful `pull` you can start the container with `run`.
 [[docker-push]]
 === Pushing Images
 
-
 Sharing an image can be achieved, by publishing it to a hosted repository. This is completely private and requires
-you to `tag` and `push` the image. To tag an image, the image identifier (imageId) is required.  It is listed when
-showing the list of all images with `docker images`. Syntax and an example are for creating a tag are:
+you to `tag` and `push` the image. When tagging an image, you can use the image identifier (imageId).  It is 
+listed when showing the list of all images with `docker images`. Syntax and an example (using imageId) for 
+creating a tag are:
 
 ----
-docker tag <imageId> <nexus-hostname>:<repository-port>/<image>:<tag>
+docker tag <imageId or imageName> <nexus-hostname>:<repository-port>/<image>:<tag>
 docker tag af340544ed62 nexus.example.com:18444/hello-world:mytag
 ----
 


### PR DESCRIPTION
Based on entire chapter review  after NEXUS-9777 work was completed to make sure no side affects as advertised.
Being NEXUS-9777 is already closed and this is my own initiative, there is no correctsponding JIRA ticket for this.

Mostly typo fixes however three more serious rewrites of note (none of which were affects from NEXUS-9777 as far as I can tell):
* The previous write suggests you do not enable v1 except in certain circumstances.  I have never agreed with this nor do I see harm in enabling it (it acts as fallback from v2, so no additional failures would be caused; if v2 and v1 fails, you're no worse off than if v2 fails & if v2 works v1 is never hit) so I rewrote the section to clarify if people are unsure they should enable it.  I hope this helps get less support and community contacts about forgetting to enable v1.
* The previous write says that if you're not authenticated, the system prompts you.  This is no longer true at least as of docker 1.10 so I adjusted it such that it says it may prompt you but otherwise you need to docker login.
* The previous write says when tagging docker image ID was required which is not true, you can use image name.

In all cases I tried to leave as much text existing as possible while maintaining the corrected statements.