### PR TITLE
Updated sentence to affirm RHC only provides security for components that Sonatype supports

### DIFF
--- a/chapter-repository-health-check.asciidoc
+++ b/chapter-repository-health-check.asciidoc
@@ -13,7 +13,7 @@ known data about the components in proxy repositories, including license informa
 and other statistics like relative usage popularity and age. {rhc} allows you to examine a high level overview of
 the available security and license data of components in an analyzed repository.
 
-When enabled, {rhc} analyzes the security of all components for which Sonatype provides support. maven2 proxy
+When enabled, {rhc} analyzes the risk of all components for which Sonatype provides security. maven2 proxy
 repositories need to have a 'Version policy' of type 'Release' configured to be analyzed. nuget proxy repositories
 support {rhc} and component identification. Some license or security data is provided as well.  Support for npm
 repositories has similar restrictions.

--- a/chapter-repository-health-check.asciidoc
+++ b/chapter-repository-health-check.asciidoc
@@ -13,13 +13,11 @@ known data about the components in proxy repositories, including license informa
 and other statistics like relative usage popularity and age. {rhc} allows you to examine a high level overview of
 the available security and license data of components in an analyzed repository.
 
-When enabled, {rhc} analyzes the risk of all components for which Sonatype provides security. maven2 proxy
-repositories need to have a 'Version policy' of type 'Release' configured to be analyzed. nuget proxy repositories
-support {rhc} and component identification. Some license or security data is provided as well.  Support for npm
-repositories has similar restrictions.
-
-Availability of component metadata varies depending on the format and is constantly improved via updates to the
-{ds}.
+{rhc} analyzes the contents of the components within each repository that is enabled. Since new versions of 
+software are continually released and new component formats are routinely added, not every component or component 
+format has corresponding data available. However, new data is made available continuously for {rhc}, with the 
+priority being influenced by frequent usage. Ultimately, the more {rhc} is used, the more it helps improve the 
+data you have access to.
 
 [[rhc-config]]
 === Configuring {rhc}

--- a/chapter-repository-health-check.asciidoc
+++ b/chapter-repository-health-check.asciidoc
@@ -13,7 +13,7 @@ known data about the components in proxy repositories, including license informa
 and other statistics like relative usage popularity and age. {rhc} allows you to examine a high level overview of
 the available security and license data of components in an analyzed repository.
 
-When enabled, {rhc} analyzes all components found in a proxy repository regardless of the format. maven2 proxy
+When enabled, {rhc} analyzes the security of all components for which Sonatype provides support. maven2 proxy
 repositories need to have a 'Version policy' of type 'Release' configured to be analyzed. nuget proxy repositories
 support {rhc} and component identification. Some license or security data is provided as well.  Support for npm
 repositories has similar restrictions.


### PR DESCRIPTION
To avoid the confusion for those who may take the statement to mean
that we supply security and license data for docker images (real use
case).