### PR TITLE
Grammar fix to Caution block in Preface Chapter

### DIFF
--- a/chapter-preface.asciidoc
+++ b/chapter-preface.asciidoc
@@ -72,7 +72,7 @@ In addition there are blocks for warnings and cautioning alerts:
 
 WARNING: Mounting the storage directory via NFS can have negative performance and stability effects.
 
-CAUTION: Ensure to complete a backup, before upgrading the repository manager.
+CAUTION: Be sure to perform a complete backup before upgrading the repository manager.
 
 Application screenshots and other images are typically included as numbered figures and referenced from the
 flowing text.


### PR DESCRIPTION
This is a minor fix. The fix will be cherrypicked to 3.1, too.