### PR TITLE
NEXUS-10209-License_Improvements

### DIFF
--- a/chapter-configuration.asciidoc
+++ b/chapter-configuration.asciidoc
@@ -918,7 +918,7 @@ agent'). To generate the report click 'Download' to produce a CSV file of listed
 
 When a {pro} license expires all functionality will be disabled in the user interface, except for the ability to 
 install a new license file. To avoid interruption of service be sure to upload a renewed license before the 
-existing license expires.  {pro} will provide a warning when the license in within 30 days of expiry.
+existing license expires.  {pro} will provide a warning when the license is within 30 days of expiry.
 
 [[admin-support]]
 === Support Features

--- a/chapter-configuration.asciidoc
+++ b/chapter-configuration.asciidoc
@@ -918,8 +918,7 @@ agent'). To generate the report click 'Download' to produce a CSV file of listed
 
 When a {pro} license expires all functionality will be disabled in the user interface, except for the ability to 
 install a new license file. To avoid interruption of service be sure to upload a renewed license before the 
-existing license expi
-
+existing license expires.  {pro} will provide a warning when the license in within 30 days of expiry.
 
 [[admin-support]]
 === Support Features
@@ -1113,4 +1112,3 @@ runtime in terms of processor, memory and threads, network connectors and storag
 
 You can copy a subsection of the text from the panel or use the 'Download' button to retrieve a JSON-formatted 
 text file.
-


### PR DESCRIPTION
* Added a line regarding the added warning.  Rest of the text seems to already match what we do (did).
* Fixed a typo (in the area).
* Removed an extra whitespace (in the area).
* Removed an extra whitespace (eof).

https://issues.sonatype.org/browse/NEXUS-10209