### PR TITLE
NEXUS-9781-rubygems-groupplus-revamp

### DIFF
--- a/chapter-rubygems.asciidoc
+++ b/chapter-rubygems.asciidoc
@@ -104,18 +104,15 @@ Minimal configuration steps are:
 - Select 'Blob store' for Storage
 - Add RubyGems repositories to the 'Members' list in the desired order
 
-A typical, useful example would be to group the proxy repository that
-proxies the RubyGems repository, a hosted gem repository with
-internal software gems, and another hosted gem repository with
-third-party gems.
+A typical, useful example would be to group the proxy repository that proxies the RubyGems repository, a hosted 
+gem repository with internal software gems, and another hosted gem repository with third-party gems.
 
-Using the repository 'URL' of the repository group as your gem
-repository URL in your client tool gives you access to the gems in
-all member repositories with one URL.
+Using the repository 'URL' of the repository group as your gem repository URL in your client tool gives you access 
+to the gems in all member repositories with one URL.
 
 Any gem added to a hosted or proxy repository becomes immediately available to all users of the gem repository 
-group. Adding a new proxy gem repository to the group makes all gems in that proxy immediately 
-available to the users as well.
+group. Adding a new proxy gem repository to the group makes all gems in that proxy immediately available to the 
+users as well.
 
 [[rubygems-config]]
 === Using Gem Repositories
@@ -159,12 +156,11 @@ repository manager requires authentication, you have to add the 'Basic Auth' aut
 configuration:
 
 ----
-$ gem sources --add
-http://myuser:mypassword@localhost:8081/repository/rubygems-group/
+$ gem sources --add http://myuser:mypassword@localhost:8081/repository/rubygems-group/
 ----
 
-If you are using the popular http://bundler.io/[Bundler] tool for tracking and installing
-gems, you need to install it with +gem+:
+If you are using the popular http://bundler.io/[Bundler] tool for tracking and installing gems, you need to 
+install it with +gem+:
 
 ----
 $ gem install bundle
@@ -196,9 +192,8 @@ mirror.http://rubygems.org
 Set for the current user (/Users/manfred/.bundle/config): "http://localhost:8081/repository/rubygems-group"
 ----
 
-With this configuration completed, you can create a +Gemfile+ and run
-+bundle install+ as usual and any downloads of gem files will be using
-the gem repository group configured as a mirror.
+With this configuration completed, you can create a +Gemfile+ and run +bundle install+ as usual and any downloads 
+of gem files will be using the gem repository group configured as a mirror.
 
 [[rubygems-deploy]]
 === Pushing Gems
@@ -240,13 +235,11 @@ Uploading gem to Nexus...
 Created
 ----
 
-By default pushing an identical version to the repository, known as
-redeployment, is not allowed in a hosted gem repository. If desired
-this configuration can be changed, although we suggest to change the
-version for each new deployment instead.
+By default pushing an identical version to the repository, known as redeployment, is not allowed in a hosted gem 
+repository. If desired this configuration can be changed, although we suggest to change the version for each new 
+deployment instead.
 
-The +nexus+ gem provides a number of additional features and
-parameters. You can access the documentation with
+The +nexus+ gem provides a number of additional features and parameters. You can access the documentation with
 
 ----
 $ gem help nexus 

--- a/chapter-rubygems.asciidoc
+++ b/chapter-rubygems.asciidoc
@@ -148,7 +148,7 @@ $ gem sources
 http://localhost:8081/repository/rubygems-group/
 ----
 
-With this setup completed any installation of new gems with +gem install gemname+ e.g., +gem install rake+ will
+With this setup completed any installation of new gems with +gem install gemname+ (e.g. +gem install rake+) will
 download from the repository manager.
 
 By default read access is available to anonymous access and no further configuration is necessary. If your

--- a/chapter-rubygems.asciidoc
+++ b/chapter-rubygems.asciidoc
@@ -23,7 +23,7 @@ Ruby has been a successful platform for developers for a long time now. The popu
 usage of gems and gem repositories means that lots of teams are downloading and exchanging lots of components on 
 a regular basis. Obviously, this can (and does) become a crunch on resources, not to mention a pain to manage.
 
-Luckily {pro} and {oss} support gem repositories. A user can connect to the repositry manager to downloads gems
+Luckily {pro} and {oss} support gem repositories. A user can connect to the repository manager to downloads gems
 from RubyGems, create proxies to other repositories, and host their own or third-party gems. Any gem downloaded
 via the repository manager needs to be downloaded from the remote repository, like RubyGems, only once and is then
 available internally from the repository manager. Gems pushed to the repository manager automatically become
@@ -37,7 +37,7 @@ The following features are included as part of the gem repository support:
 
 * Proxy repository for connecting to remote gem repositories and caching gems on the repository manager to avoid
   duplicate downloads and wasted bandwidth and time
-* Hosted repository for hosting gems package and providing them to your users
+* Hosted repository for hosting gem packages and providing them to users
 * Repository groups for merging multiple hosted and proxy gem repositories and easily exposing them as one URL to 
   all users
 
@@ -113,8 +113,8 @@ Using the repository 'URL' of the repository group as your gem
 repository URL in your client tool gives you access to the gems in
 all member repositories with one URL.
 
-Any new gem added to any hosted gem repository or proxied becomes immediately available to all users of the gem 
-repository group. Adding a new proxy gem repository to the group makes all gems in that proxy immediately 
+Any gem added to a hosted or proxy repository becomes immediately available to all users of the gem repository 
+group. Adding a new proxy gem repository to the group makes all gems in that proxy immediately 
 available to the users as well.
 
 [[rubygems-config]]

--- a/chapter-rubygems.asciidoc
+++ b/chapter-rubygems.asciidoc
@@ -15,7 +15,7 @@ really find success, a development community needs to exists. At the heart of ev
 especially those like Ruby, where open source projects are one of the most critical elements, the community needs 
 a place to host and share their projects.
 
-Enter link:https://rubygems.org[RubyGems hosted at rubygems.org] - the most popular and leading gem hosting 
+Enter RubyGems hosted at link:https://rubygems.org[rubygems.org] - the most popular and leading gem hosting 
 service supporting the Ruby community. Here, a large variety of open source Ruby projects supply their gems for 
 download to all users.
 
@@ -70,52 +70,53 @@ metadata files of a proxy gem repository.
 [[rubygems-hosted-private]]
 === Private Hosted Gem Repositories
 
-A private Gem repository on repository manager can be used as target to push your own gems as well as third-party
-gems and subsequently provide them to your users. It is good practice to create two separate hosted Gem
-repositories for internal and third-party gems.
+A private Gem repository can be used as a target to push your own gems as well as third-party gems and 
+subsequently provide them to your users. It is a good practice to create two separate hosted Gem repositories for 
+internal and third-party gems.
 
-To create a hosted Gem repository, simply create a new 'Hosted
-Repository' and set the 'Provider' to +Rubygems+. A sample configuration for an internal
-hosted Gem repository is displayed in Rubygems hosted.
+To create a hosted Gem repository, create a new repository using the recipe  'rubygems (hosted)' as documented in 
+<<admin-repositories>>.
+
+Minimal configuration steps are:
+
+- Define 'Name'
+- Select a 'Blob store' for 'Storage'
+
+The Gem repository information is immediately updated as gems are pushed to the repository or deleted from it.
 
 ////
-Add link to hosted, insert image
-////
-
-The Gem repository information is immediately updated as gems are
-pushed to the repository or deleted from it.
-
 A scheduled task can be used to rebuild the metadata of a hosted gem
 repository and can be configured as documented in Scheduled Tasks.
+////
 
 [[rubygems-group]]
 === Grouping Gem Repositories
 
 A repository group is the recommended way to expose all your Gem repositories to your users, without needing any
 further client side configuration after initial setup. A repository group allows you to expose the aggregated
-content of multiple proxy and hosted Gem repositories with one URL to +gem+ and other tools.  This is possible for
-Gem repositories by creating a new 'Repository Group' with the 'Provider' set to +Rubygems+ as documented in
-Repository Groups.
+content of multiple proxy and hosted Gem repositories with one URL to +gem+ and other tools.
+
+To create a RubyGems group repository, create a new repository using the recipe 'rubygems (group)' as documented 
+in <<admin-repositories>>.
+
+Minimal configuration steps are:
+
+- Define Name
+- Select Blob store for Storage
+- Add RubyGems repositories to the Members list in the desired order
 
 A typical, useful example would be to group the proxy repository that
 proxies the RubyGems repository, a hosted Gem repository with
 internal software gems, and another hosted Gem repository with
-third-party gems. The configuration for such a setup is displayed in
-insert image.
+third-party gems.
 
-////
-add an image
-////
-
-Using the 'Repository Path' of the repository group as your Gem
+Using the repository 'URL' of the repository group as your Gem
 repository URL in your client tool gives you access to the gems in
-all three repositories with one URL.
+all member repositories with one URL.
 
-Any new gem added to the remote proxy Gem repositories or the hosted
-Gem repositories becomes immediately available to all users of the Gem
-repository group. Adding a new proxy Gem repository to the group makes
-all gems immediately available to the users as well.
-
+Any new gem added to any hosted Gem repository or proxied becomes immediately available to all users of the Gem 
+repository group. Adding a new proxy Gem repository to the group makes all gems immediately available to the users 
+as well.
 
 [[rubygems-config]]
 === Using Gem Repositories
@@ -123,26 +124,23 @@ all gems immediately available to the users as well.
 Once you have configured the repository manager with the Gem repository group, you can add it to your
 configuration for the +gem+ command line tool.
 
-You can add the URL gems repository or better the Gem repository group using the 'Repository Path' from the
-repository list with a command like
+You can add the URL of a RubyGems repository or group using the 'URL' from the repository list with a command like
 
 ----
-gem sources --add http://localhost:8081/nexus/content/groups/gems-all/
+$ gem sources --add http://localhost:8081/repository/rubygems-group/
 ----
 
 In order to take full advantage of the repository manager and the proxying of gems, you should remove any other
-sources. By default +https://rubygems.org/+ is configured and this can be removed with
+sources. By default +https://rubygems.org/+ is configured in +gem+ and this can be removed with
 
 ----
 $ gem sources --remove https://rubygems.org/
-https://rubygems.org/ removed from sources
 ----
 
 Subsequently you should clear the local cache with
 
 ----
 $ gem sources -c
-*** Removed specs cache ***
 ----
 
 To check a successful configuration you can run 
@@ -151,7 +149,7 @@ To check a successful configuration you can run
 $ gem sources
 *** CURRENT SOURCES ***
 
-http://localhost:8081/nexus/content/groups/gems-all/
+http://localhost:8081/repository/rubygems-group/
 ----
 
 With this setup completed any installation of new gems with +gem install GEMNAME+ e.g., +gem install rake+ will
@@ -163,7 +161,7 @@ configuration:
 
 ----
 $ gem sources --add
-http://myuser:mypassword@localhost:8081/nexus/content/repositories/gems-all/
+http://myuser:mypassword@localhost:8081/repository/rubygems-group/
 ----
 
 If you are using the popular http://bundler.io/[Bundler] tool for tracking and installing
@@ -187,24 +185,21 @@ To use the repository manager with Bundler, you have to configure the Gem reposi
 
 ----
 $ bundle config mirror.http://rubygems.org
-http://localhost:8081/nexus/content/repositories/gems-all
+http://localhost:8081/repository/rubygems-group/
 ----
 
 You can confirm the configuration succeeded by checking the configuration:
 
 ----
 $ bundle config
-Settings are listed in order of priority. 
-The top value will be used.
+Settings are listed in order of priority. The top value will be used.
 mirror.http://rubygems.org
-Set for the current user (/Users/manfred/.bundle/config): 
-"http://localhost:8081/nexus/content/repositories/gems-all"
+Set for the current user (/Users/manfred/.bundle/config): "http://localhost:8081/repository/rubygems-group"
 ----
 
 With this configuration completed, you can create a Gemfile and run
 +bundle install+ as usual and any downloads of gem files will be using
 the Gem repository group configured as a mirror.
-
 
 [[rubygems-deploy]]
 === Pushing Gems
@@ -230,11 +225,11 @@ Done installing
 ----
 
 After successful installation you can push your gem to a desired repository. The initial invocation will request
-the URL for the GEM repository and the credentials needed for deployment. Subsequent pushes will used the cached
+the URL for the GEM repository and the credentials needed for deployment. Subsequent pushes will use the cached
 information.
 
 ----
-$gem nexus example-1.0.0.gem
+$ gem nexus example-1.0.0.gem
 Enter the URL of the rubygems repository on a Nexus server
 URL:   http://localhost:8081/nexus/content/repositories/gems-internal
 The Nexus URL has been stored in ~/.gem/nexus
@@ -246,7 +241,7 @@ Uploading gem to Nexus...
 Created
 ----
 
-By default pushing an identical version to the repository, as known as
+By default pushing an identical version to the repository, known as
 redeployment, is not allowed in a hosted Gem repository. If desired
 this configuration can be changed, although we suggest to change the
 version for each new deployment instead.
@@ -261,10 +256,9 @@ $ gem help nexus
 E.g. you can access a list of all configured repositories with
 
 ----
-$gem nexus --all-repos
+$ gem nexus --all-repos
 
-DEFAULT:
-http://localhost:8081/nexus/content/repositories/gems-internal
+DEFAULT: http://localhost:8081/repository/rubygems-hosted
 ----
 
 ////

--- a/chapter-rubygems.asciidoc
+++ b/chapter-rubygems.asciidoc
@@ -20,26 +20,25 @@ service supporting the Ruby community. Here, a large variety of open source Ruby
 download to all users.
 
 Ruby has been a successful platform for developers for a long time now. The popularity of Ruby and therefore the 
-usage of gems and Gem repositories means that lots of teams are downloading and exchanging lots of components on 
+usage of gems and gem repositories means that lots of teams are downloading and exchanging lots of components on 
 a regular basis. Obviously, this can (and does) become a crunch on resources, not to mention a pain to manage.
 
-Luckily {pro} and {oss} support Gem repositories. A user can connect to the repositry manager to downloads gems
+Luckily {pro} and {oss} support gem repositories. A user can connect to the repositry manager to downloads gems
 from RubyGems, create proxies to other repositories, and host their own or third-party gems. Any gem downloaded
 via the repository manager needs to be downloaded from the remote repository, like RubyGems, only once and is then
 available internally from the repository manager. Gems pushed to the repository manager automatically become
 available to everyone else in your organization.  Using the repository manager as a proxy avoids the overhead of
 teams and individual developers having to repeatedly download components or share components in a haphazard and
 disorganized manner.
-//this should be updated before we go live
-IMPORTANT: Gem repository support is a feature of version 2.11 and higher, and is available in {pro} and {oss} 
-editions.
 
-The following features are included as part of the Gem repository support:
+IMPORTANT: Gem repository support is a feature of version 3.1 and higher
 
-* Proxy repository for connecting to remote Gem repositories and caching gems on the repository manager to avoid
+The following features are included as part of the gem repository support:
+
+* Proxy repository for connecting to remote gem repositories and caching gems on the repository manager to avoid
   duplicate downloads and wasted bandwidth and time
 * Hosted repository for hosting gems package and providing them to your users
-* Repository groups for merging multiple hosted and proxy Gem repositories and easily exposing them as one URL to 
+* Repository groups for merging multiple hosted and proxy gem repositories and easily exposing them as one URL to 
   all users
 
 TIP: None of this functionality requires Ruby (or any extra tooling) to be installed on the operating system
@@ -51,7 +50,7 @@ running the repository manager.
 To reduce duplicate downloads and improve download speeds for your developers, continuous integration servers and 
 other systems using +gem+, you should proxy the RubyGems repository and any other repositories you require.
 
-To proxy an external Gem repository, like RubyGems, you simply create a new repository using the recipe 
+To proxy an external gem repository, like RubyGems, you simply create a new repository using the recipe 
 'rubygems (proxy)' as documented in <<admin-repositories>>.
 
 Minimal configuration steps are:
@@ -70,11 +69,11 @@ metadata files of a proxy gem repository.
 [[rubygems-hosted-private]]
 === Private Hosted Gem Repositories
 
-A private Gem repository can be used as a target to push your own gems as well as third-party gems and 
-subsequently provide them to your users. It is a good practice to create two separate hosted Gem repositories for 
+A private gem repository can be used as a target to push your own gems as well as third-party gems and 
+subsequently provide them to your users. It is a good practice to create two separate hosted gem repositories for 
 internal and third-party gems.
 
-To create a hosted Gem repository, create a new repository using the recipe  'rubygems (hosted)' as documented in 
+To create a hosted gem repository, create a new repository using the recipe 'rubygems (hosted)' as documented in 
 <<admin-repositories>>.
 
 Minimal configuration steps are:
@@ -82,7 +81,7 @@ Minimal configuration steps are:
 - Define 'Name'
 - Select a 'Blob store' for 'Storage'
 
-The Gem repository information is immediately updated as gems are pushed to the repository or deleted from it.
+The gem repository information is immediately updated as gems are pushed to the repository or deleted from it.
 
 ////
 A scheduled task can be used to rebuild the metadata of a hosted gem
@@ -92,39 +91,39 @@ repository and can be configured as documented in Scheduled Tasks.
 [[rubygems-group]]
 === Grouping Gem Repositories
 
-A repository group is the recommended way to expose all your Gem repositories to your users, without needing any
+A repository group is the recommended way to expose all your gem repositories to your users, without needing any
 further client side configuration after initial setup. A repository group allows you to expose the aggregated
-content of multiple proxy and hosted Gem repositories with one URL to +gem+ and other tools.
+content of multiple proxy and hosted gem repositories with one URL to +gem+ and other tools.
 
-To create a RubyGems group repository, create a new repository using the recipe 'rubygems (group)' as documented 
+To create a gem group repository, create a new repository using the recipe 'rubygems (group)' as documented 
 in <<admin-repositories>>.
 
 Minimal configuration steps are:
 
-- Define Name
-- Select Blob store for Storage
-- Add RubyGems repositories to the Members list in the desired order
+- Define 'Name'
+- Select 'Blob store' for Storage
+- Add RubyGems repositories to the 'Members' list in the desired order
 
 A typical, useful example would be to group the proxy repository that
-proxies the RubyGems repository, a hosted Gem repository with
-internal software gems, and another hosted Gem repository with
+proxies the RubyGems repository, a hosted gem repository with
+internal software gems, and another hosted gem repository with
 third-party gems.
 
-Using the repository 'URL' of the repository group as your Gem
+Using the repository 'URL' of the repository group as your gem
 repository URL in your client tool gives you access to the gems in
 all member repositories with one URL.
 
-Any new gem added to any hosted Gem repository or proxied becomes immediately available to all users of the Gem 
-repository group. Adding a new proxy Gem repository to the group makes all gems immediately available to the users 
-as well.
+Any new gem added to any hosted gem repository or proxied becomes immediately available to all users of the gem 
+repository group. Adding a new proxy gem repository to the group makes all gems in that proxy immediately 
+available to the users as well.
 
 [[rubygems-config]]
 === Using Gem Repositories
 
-Once you have configured the repository manager with the Gem repository group, you can add it to your
+Once you have configured the repository manager with the gem repository group, you can add it to your
 configuration for the +gem+ command line tool.
 
-You can add the URL of a RubyGems repository or group using the 'URL' from the repository list with a command like
+You can add the URL of a gem repository or group using the 'URL' from the repository list with a command like
 
 ----
 $ gem sources --add http://localhost:8081/repository/rubygems-group/
@@ -152,7 +151,7 @@ $ gem sources
 http://localhost:8081/repository/rubygems-group/
 ----
 
-With this setup completed any installation of new gems with +gem install GEMNAME+ e.g., +gem install rake+ will
+With this setup completed any installation of new gems with +gem install gemname+ e.g., +gem install rake+ will
 download from the repository manager.
 
 By default read access is available to anonymous access and no further configuration is necessary. If your
@@ -181,7 +180,7 @@ Done installing documentation for bundle, bundler after 4 seconds
 2 gems installed
 ----
 
-To use the repository manager with Bundler, you have to configure the Gem repository group as a mirror:
+To use the repository manager with Bundler, you have to configure the gem repository group as a mirror:
 
 ----
 $ bundle config mirror.http://rubygems.org
@@ -197,20 +196,20 @@ mirror.http://rubygems.org
 Set for the current user (/Users/manfred/.bundle/config): "http://localhost:8081/repository/rubygems-group"
 ----
 
-With this configuration completed, you can create a Gemfile and run
+With this configuration completed, you can create a +Gemfile+ and run
 +bundle install+ as usual and any downloads of gem files will be using
-the Gem repository group configured as a mirror.
+the gem repository group configured as a mirror.
 
 [[rubygems-deploy]]
 === Pushing Gems
 
-At this point you have set up the various Gem repositories on the repository manager (proxy, hosted, and group),
+At this point you have set up the various gem repositories on the repository manager (proxy, hosted and group),
 and are successfully using them for installing new gems on your systems. A next step can be to push gems to hosted
-Gem repositories to provide them to other users. All this can be achieved on the command line with the features of
+gem repositories to provide them to other users. All this can be achieved on the command line with the features of
 the +nexus+ gem.
 
 The +nexus+ gem is available at RubyGems and provides features to interact with {pro} including pushing gems to a
-hosted Gem repository including the necessary authentication.
+hosted gem repository including the necessary authentication.
 
 You can install the nexus gem with
 
@@ -225,13 +224,13 @@ Done installing
 ----
 
 After successful installation you can push your gem to a desired repository. The initial invocation will request
-the URL for the GEM repository and the credentials needed for deployment. Subsequent pushes will use the cached
+the URL for the gem repository and the credentials needed for deployment. Subsequent pushes will use the cached
 information.
 
 ----
 $ gem nexus example-1.0.0.gem
 Enter the URL of the rubygems repository on a Nexus server
-URL:   http://localhost:8081/nexus/content/repositories/gems-internal
+URL:   http://localhost:8081/repository/rubygems-hosted
 The Nexus URL has been stored in ~/.gem/nexus
 Enter your Nexus credentials
 Username:   admin
@@ -242,7 +241,7 @@ Created
 ----
 
 By default pushing an identical version to the repository, known as
-redeployment, is not allowed in a hosted Gem repository. If desired
+redeployment, is not allowed in a hosted gem repository. If desired
 this configuration can be changed, although we suggest to change the
 version for each new deployment instead.
 


### PR DESCRIPTION
* Revamped the RubyGems group section from NX2 port after rework in https://issues.sonatype.org/browse/NEXUS-9781
* Also reviewed hosted, using gem repositories and pushing gems which seemed thus far untouched
* Minor typo fixes
* Changed link in introduction (it looked like it was including information on hosted as written)
* I removed the response from 2 commands so it would not be confused with the commands themselves and would be consistent.  I wasn't sure on this but the commands are verified at the end, so I felt it was unnecessary text.
* 114ized page (I went ahead and did it after +1s since I am squash merging anyway; sorry if this breaks protocol)

NOTE: I intentionally did not include images because I did not see the value.  One place I was wishy washy, I left the comment in there, the rest I struck.  If people believe worth feel free to note on PR and I can or add in yourself (now or later).

http://bamboo.s/browse/BOOK-NEXUS155-3