### PR TITLE
Remote storage PyPi fix

### DIFF
--- a/chapter-pypi.asciidoc
+++ b/chapter-pypi.asciidoc
@@ -29,7 +29,7 @@ To proxy a PyPI package, you simply create a new 'pypi(proxy)' recipe as documen
 detail. Minimal configuration steps are:
 
 * Define 'Name'
-* Define URL for 'Remote storage' e.g. https://pypi.python.org/pypi[https://pypi.python.org/pypi]
+* Define URL for 'Remote storage' e.g. https://pypi.python.org/[https://pypi.python.org/]
 * Pick a 'Blob store' for 'Storage'
 
 The repository manager can access Python packages and tools from the index. The proxy repository for PyPI 


### PR DESCRIPTION
Minor fix to Remote Storage URL for PyPi based on some user feedback.