### PR TITLE
Correction to instruction that user needs both URL and nexus section in bowerrc file

### DIFF
--- a/chapter-bower.asciidoc
+++ b/chapter-bower.asciidoc
@@ -149,7 +149,7 @@ jquery#2.2.0 bower_components/jquery
 ----
 
 If anonymous access to the repository manager is disabled, you have to specify the credentials for the accessing
-the repository manager as part of the URL like `http://username:password@host:port/repository/bower-all` or add a
+the repository manager as part of the URL like `http://username:password@host:port/repository/bower-all` and add a
 `nexus` section to your `.bowerrc` file.
 
 ----


### PR DESCRIPTION
Updated.
TODO: Cherrypick to 3.1