### PR TITLE
NEXUS-10660-pypi-ruby-chapter-add

### DIFF
--- a/chapter-pypi.asciidoc
+++ b/chapter-pypi.asciidoc
@@ -1,0 +1,216 @@
+[[pypi]]
+== PyPI Repositories
+{inall}
+
+[[pypi-introduction]]
+=== Introduction
+
+The Python Package Index, or PyPI, is a vast repository of open-source Python packages supplied by the worldwide 
+community of Python developers. The official PyPI is available for searches at
+https://pypi.python.org/pypi[https://pypi.python.org/pypi], 
+and the site itself is maintained by the https://www.python.org/psf/[Python Software Foundation].
+
+Both {pro} and {oss} support proxying the Python Package Index. This allows the repository manager to take 
+advantage of the packages in the official Python Package Index without incurring repeated downloads. This will 
+reduce time and bandwidth usage for accessing Python packages.
+
+Also, you can publish your own packages to a private index as a hosted repository on the repository manager, then 
+expose the remote and private repositories as a repository group, which is a repository that merges and exposes 
+the contents of multiple repositories in one convenient URL.
+
+TIP: If using pip with the repository manager, you should consider setting up your repository manager to use SSL 
+as documented in <<ssl>>.  Otherwise, you will likely need to put --trusted-host additions at the end of many 
+commands or further configure pip to trust your repository manager.
+
+[[pypi-proxy]]
+=== Proxying PyPI Repositories
+
+You can set up a PyPI proxy repository to access a remote repository location, such as the PyPI repository at 
+https://pypi.python.org/pypi[https://pypi.python.org/pypi]. The index is maintained as the default location for  
+Python packages.
+
+To proxy a PyPI package, you simply create a new 'pypi(proxy)' recipe as documented in <<proxy-repository>>, in 
+detail. Minimal configuration steps are:
+
+* Define 'Name'
+* Define URL for 'Remote storage' e.g. https://pypi.python.org/[https://pypi.python.org/]
+* Pick a 'Blob store' for 'Storage'
+
+The repository manager can access Python packages and tools from the index. The proxy repository for PyPI 
+packages provides a cache of files available on the index. This allows the local network client to access 
+components from the Python Package Index more reliably.
+
+The proxy configuration for a PyPI proxy repository includes a configuration URL to access the index. Users will 
+be able to browse and search assets against a remote repository, as mentioned in <<pypi-browse-search>>.
+
+
+[[pypi-hosted]]
+=== Hosting PyPI Repositories
+
+Creating a PyPI hosted repository allows you to upload packages in the repository manager. The hosted 
+repository acts as an authoritative location for packages fetched from the Python index.
+
+To host a PyPI package, create a new 'pypi(hosted)' recipe as documented in <<hosted-repository>>, in detail. 
+Minimal configuration steps are:
+
+* Define 'Name' - e.g. +pypi-internal+
+* Pick a 'Blob store' for 'Storage'
+
+
+[[pypi-group]]
+=== PyPI Repository Groups
+
+A repository group is the recommended way to expose all your PyPI repositories from the repository manager to 
+your users, with minimal additional client side configuration. A repository group allows you to expose the 
+aggregated content of multiple proxy and hosted repositories as well as other repository groups with one URL in 
+tool configuration. PyPI group repositories can be created with the 'pypi(group)' recipe as documented in 
+<<repository-group>>.
+
+Minimal configuration steps are:
+
+* Define 'Name' - e.g. +pypi-all+
+* Pick a 'Blob store' for 'Storage'
+* Add PyPI repositories to the 'Members' list in the desired order
+
+
+[[pypi-installation]]
+=== Installing PyPI Client Tools
+
+The latest versions of such Linux distributions as CentOS and Ubuntu come packaged with Python 2.7 and 
+https://pip.pypa.io/en/stable/[pip], a tool for installing and managing Python packages from the index. For Mac 
+OS X and Microsoft Windows, download and install a Python version compatible with the repository manager from
+https://www.python.org/downloads/[https://www.python.org/downloads/]. Download the pip installer from 
+https://pip.pypa.io/en/stable/installing/[https://pip.pypa.io/en/stable/installing/].
+
+NOTE: {pro} and {oss} support specific versions of Python, pip, and setuptools. For Python the repository 
+manager supports the latest of releases 2 and 3, as well as some earlier versions (i.e. 2.7 and earlier, 3.5 and 
+earlier). For pip versions 7 and 8 are supported. The latest two versions of setuptools, used to build and 
+distribute Python dependencies, are compatible with the repository manager.
+
+
+[[pypi-configuration]]
+=== Configuring PyPI Client Tools
+
+NOTE: Depending on your preference for either https://pypi.python.org/pypi/setuptools[setuptools], 
+https://pypi.python.org/pypi/twine[twine], https://docs.python.org/2.7/library/distutils.html[distutils], and 
+pip your proxy and hosted configuration may vary.
+
+Once you have installed all necessary client tools from the Python Package Index, you can create and configure 
+a +.pypirc+ file to reference packages stored in the repository manager. Depending on your Python configuration 
+you can manage your repository groups with +pip.conf+ or +setup.cfg+ to have all commands, such as search and 
+install, run against your project.
+
+*Configuring a proxy repository to use easy_install*
+
+You can create a +setup.cfg+, if using +easy_install+. The +index-url+ is the tag created to specify 
+the base URL for the PyPI package. In this example +index-url+ is set for a proxy repository:
+
+----
+[easy_install]
+index-url = http://localhost:8081/repository/pypi-proxy/simple
+----
+
+If you prefer to configure easy_install for hosted (+pypi-internal+) or group (+pypi-all+) adjust the 
+file accordingly.
+
+*Configuring your hosted repository with .pypirc*
+
+If you are authoring your own packages and want to distribute them to other users in your organization, you have 
+to upload them to a hosted repository on the repository manager. The +.pypirc+ holds your credentials for 
+authentication when hosting a PyPI repository.
+
+In the example +.pypirc+ file below, specify the URL you want to deploy to the target hosted repository in 
+the +repository+ value. Add +username+ and +password+ values to access the repository manager. The +.pypirc+ file 
+contains distutils, a default server used by PyPI that provides upload commands that stores assets and 
+authentication information.
+
+----
+[distutils]
+index-servers =
+   nexus
+ 
+[nexus]
+repository = http://localhost:8081/repository/pypi-internal/
+username = admin
+password = admin123
+----
+
+NOTE: If you have multiple hosted repositories, you can add them to the +.pypirc+ file, each with a different 
+name, pointing to the corresponding respository URL.
+
+After this is configured, you can upload packages to the hosted repository, as explained in <<pypi-upload>>.
+
+*Global pip.conf file with a repository group*
+
+If you want your +pip.conf+ to install or search Python within a group, configure the file to include the 
+repository group URL.
+
+----
+[global]
+index = http://localhost:8081/repository/pypi-all/pypi
+index-url = http://localhost:8081/repository/pypi-all/simple
+----
+
+If you prefer to configure your global +pip.conf+ for proxy (+pypi-proxy+) or hosted (+pypi-internal+) adjust the 
+file accordingly.
+
+[[pypi-ssl]]
+=== SSL Usage for PyPI Repositories
+
+You can proxy Python packages over HTTPS to ensure a secure connection with a self-signed certificate. This works 
+for proxy, hosted, and group repositories. To set up the repository manager to serve HTTPS follow the 
+configuration steps in <<ssl>>.
+
+Also, you can set up pip to use the certificate to enable SSL and fetch packages securely. Additional
+configuration is necessary for the HTTPS client implementation to work. This assumes the repository manager has 
+already been set up to use SSL, so verify your certificate works. Run the following command:
+
+----
+openssl verify <example-cerfificate>
+----
+
+When your certificate is proven to work, update your +pip.conf+. Here is an example configuration file for a 
+repository group:
+----
+[global]
+index = https://localhost:8443/repository/pypi-all/pypi
+index-url = https://localhost:8443/repository/pypi-all/simple
+cert = nexus.pem
+----
+
+[[pypi-browse-search]]
+=== Browsing PyPI Repositories and Searching Packages
+
+You can browse PyPI repositories in the user interface inspecting the components and assets and their details, as 
+described in <<browse-browse>>.
+
+Searching for PyPI packages can be performed in the user interface, as described in <<search-components>>. It 
+finds all packages that are currently stored in the repository manager, either because they have been pushed
+to a hosted repository or they have been proxied from an upstream repository and cached in the repository manager.
+
+From the command line you can search available PyPI packages defined in your configuration. This method is 
+limited to pip (+pip.conf+). To search, run:
+
+----
+pip search example-package
+----
+
+[[pypi-upload]]
+=== Uploading PyPI Packages
+
+NOTE: The steps to upload a PyPI package will vary if your system is configured with setuptools or twine.
+
+After you configure your +.pypirc+ you can upload packages from the index to the repository manager.
+
+In the example below, twine is invoked to tell your repository what server to use when uploading a package. The 
++-r+ flag is used to find the +nexus+ server in your +.pypirc+.
+
+----
+twine upload -r nexus <filename>
+----
+
+////
+/* Local Variables: */
+/* ispell-personal-dictionary: "ispell.dict" */
+/* End:             */
+////

--- a/chapter-rubygems.asciidoc
+++ b/chapter-rubygems.asciidoc
@@ -1,0 +1,260 @@
+[[rubygems]]
+== Ruby, RubyGems and Gem Repositories
+
+{inall}
+
+=== Introduction
+
+For developers using the https://www.ruby-lang.org[Ruby] programming language, the +gem+ tool serves as their 
+package management solution. In fact, since version 1.9 of Ruby, it has been included as part of the default Ruby 
+library. Packages are called 'gems' and, just like all package managers, this allows for ease of use when 
+distributing programs or libraries.
+
+Of course, package management really only goes as far as improving distribution.  A great feat certainly, but to 
+really find success, a development community needs to exists. At the heart of every development community, 
+especially those like Ruby, where open source projects are one of the most critical elements, the community needs 
+a place to host and share their projects.
+
+Enter RubyGems hosted at link:https://rubygems.org[rubygems.org] - the most popular and leading gem hosting 
+service supporting the Ruby community. Here, a large variety of open source Ruby projects supply their gems for 
+download to all users.
+
+Ruby has been a successful platform for developers for a long time now. The popularity of Ruby and therefore the 
+usage of gems and gem repositories means that lots of teams are downloading and exchanging lots of components on 
+a regular basis. Obviously, this can (and does) become a crunch on resources, not to mention a pain to manage.
+
+Luckily {pro} and {oss} support gem repositories. A user can connect to the repository manager to downloads gems
+from RubyGems, create proxies to other repositories, and host their own or third-party gems. Any gem downloaded
+via the repository manager needs to be downloaded from the remote repository, like RubyGems, only once and is then
+available internally from the repository manager. Gems pushed to the repository manager automatically become
+available to everyone else in your organization.  Using the repository manager as a proxy avoids the overhead of
+teams and individual developers having to repeatedly download components or share components in a haphazard and
+disorganized manner.
+
+IMPORTANT: Gem repository support is a feature of version 3.1 and higher
+
+The following features are included as part of the gem repository support:
+
+* Proxy repository for connecting to remote gem repositories and caching gems on the repository manager to avoid
+  duplicate downloads and wasted bandwidth and time
+* Hosted repository for hosting gem packages and providing them to users
+* Repository groups for merging multiple hosted and proxy gem repositories and easily exposing them as one URL to 
+  all users
+
+TIP: None of this functionality requires Ruby (or any extra tooling) to be installed on the operating system
+running the repository manager.
+
+[[rubygems-proxy]]
+=== Proxying Gem Repositories
+
+To reduce duplicate downloads and improve download speeds for your developers, continuous integration servers and 
+other systems using +gem+, you should proxy the RubyGems repository and any other repositories you require.
+
+To proxy an external gem repository, like RubyGems, you simply create a new repository using the recipe 
+'rubygems (proxy)' as documented in <<admin-repositories>>.
+
+Minimal configuration steps are:
+
+- Define 'Name'
+- Define URL for 'Remote storage' e.g. `https://rubygems.org` (the official URL for RubyGems.org)
+- Select a 'Blob store' for 'Storage'
+
+Further configuration details are available in <<admin-repository-repositories>>.
+
+////
+Scheduled tasks can be used to purge broken metadata of a proxy gem repository as well as to synchronize the
+metadata files of a proxy gem repository.
+////
+
+[[rubygems-hosted-private]]
+=== Private Hosted Gem Repositories
+
+A private gem repository can be used as a target to push your own gems as well as third-party gems and 
+subsequently provide them to your users. It is a good practice to create two separate hosted gem repositories for 
+internal and third-party gems.
+
+To create a hosted gem repository, create a new repository using the recipe 'rubygems (hosted)' as documented in 
+<<admin-repositories>>.
+
+Minimal configuration steps are:
+
+- Define 'Name'
+- Select a 'Blob store' for 'Storage'
+
+The gem repository information is immediately updated as gems are pushed to the repository or deleted from it.
+
+////
+A scheduled task can be used to rebuild the metadata of a hosted gem
+repository and can be configured as documented in Scheduled Tasks.
+////
+
+[[rubygems-group]]
+=== Grouping Gem Repositories
+
+A repository group is the recommended way to expose all your gem repositories to your users, without needing any
+further client side configuration after initial setup. A repository group allows you to expose the aggregated
+content of multiple proxy and hosted gem repositories with one URL to +gem+ and other tools.
+
+To create a gem group repository, create a new repository using the recipe 'rubygems (group)' as documented 
+in <<admin-repositories>>.
+
+Minimal configuration steps are:
+
+- Define 'Name'
+- Select 'Blob store' for Storage
+- Add RubyGems repositories to the 'Members' list in the desired order
+
+A typical, useful example would be to group the proxy repository that proxies the RubyGems repository, a hosted 
+gem repository with internal software gems, and another hosted gem repository with third-party gems.
+
+Using the repository 'URL' of the repository group as your gem repository URL in your client tool gives you access 
+to the gems in all member repositories with one URL.
+
+Any gem added to a hosted or proxy repository becomes immediately available to all users of the gem repository 
+group. Adding a new proxy gem repository to the group makes all gems in that proxy immediately available to the 
+users as well.
+
+[[rubygems-config]]
+=== Using Gem Repositories
+
+Once you have configured the repository manager with the gem repository group, you can add it to your
+configuration for the +gem+ command line tool.
+
+You can add the URL of a gem repository or group using the 'URL' from the repository list with a command like
+
+----
+$ gem sources --add http://localhost:8081/repository/rubygems-group/
+----
+
+In order to take full advantage of the repository manager and the proxying of gems, you should remove any other
+sources. By default +https://rubygems.org/+ is configured in +gem+ and this can be removed with
+
+----
+$ gem sources --remove https://rubygems.org/
+----
+
+Subsequently you should clear the local cache with
+
+----
+$ gem sources -c
+----
+
+To check a successful configuration you can run 
+
+----
+$ gem sources
+*** CURRENT SOURCES ***
+
+http://localhost:8081/repository/rubygems-group/
+----
+
+With this setup completed any installation of new gems with +gem install gemname+ (e.g. +gem install rake+) will
+download from the repository manager.
+
+By default read access is available to anonymous access and no further configuration is necessary. If your
+repository manager requires authentication, you have to add the 'Basic Auth' authentication details to the sources
+configuration:
+
+----
+$ gem sources --add http://myuser:mypassword@localhost:8081/repository/rubygems-group/
+----
+
+If you are using the popular http://bundler.io/[Bundler] tool for tracking and installing gems, you need to 
+install it with +gem+:
+
+----
+$ gem install bundle
+Fetching: bundler-1.7.7.gem (100%)
+Successfully installed bundler-1.7.7
+Fetching: bundle-0.0.1.gem (100%)
+Successfully installed bundle-0.0.1
+Parsing documentation for bundle-0.0.1
+Installing ri documentation for bundle-0.0.1
+Parsing documentation for bundler-1.7.7
+Installing ri documentation for bundler-1.7.7
+Done installing documentation for bundle, bundler after 4 seconds
+2 gems installed
+----
+
+To use the repository manager with Bundler, you have to configure the gem repository group as a mirror:
+
+----
+$ bundle config mirror.http://rubygems.org
+http://localhost:8081/repository/rubygems-group/
+----
+
+You can confirm the configuration succeeded by checking the configuration:
+
+----
+$ bundle config
+Settings are listed in order of priority. The top value will be used.
+mirror.http://rubygems.org
+Set for the current user (/Users/manfred/.bundle/config): "http://localhost:8081/repository/rubygems-group"
+----
+
+With this configuration completed, you can create a +Gemfile+ and run +bundle install+ as usual and any downloads 
+of gem files will be using the gem repository group configured as a mirror.
+
+[[rubygems-deploy]]
+=== Pushing Gems
+
+At this point you have set up the various gem repositories on the repository manager (proxy, hosted and group),
+and are successfully using them for installing new gems on your systems. A next step can be to push gems to hosted
+gem repositories to provide them to other users. All this can be achieved on the command line with the features of
+the +nexus+ gem.
+
+The +nexus+ gem is available at RubyGems and provides features to interact with {pro} including pushing gems to a
+hosted gem repository including the necessary authentication.
+
+You can install the nexus gem with
+
+----
+$ gem install nexus
+Fetching: nexus-1.2.1.gem (100%)
+...
+Successfully installed nexus-1.2.1
+Parsing documentation for nexus-1.2.1
+Installing ri documentation for nexus-1.2.1
+Done installing
+----
+
+After successful installation you can push your gem to a desired repository. The initial invocation will request
+the URL for the gem repository and the credentials needed for deployment. Subsequent pushes will use the cached
+information.
+
+----
+$ gem nexus example-1.0.0.gem
+Enter the URL of the rubygems repository on a Nexus server
+URL:   http://localhost:8081/repository/rubygems-hosted
+The Nexus URL has been stored in ~/.gem/nexus
+Enter your Nexus credentials
+Username:   admin
+Password:
+Your Nexus credentials has been stored in /Users/manfred/.gem/nexus
+Uploading gem to Nexus...
+Created
+----
+
+By default pushing an identical version to the repository, known as redeployment, is not allowed in a hosted gem 
+repository. If desired this configuration can be changed, although we suggest to change the version for each new 
+deployment instead.
+
+The +nexus+ gem provides a number of additional features and parameters. You can access the documentation with
+
+----
+$ gem help nexus 
+----
+
+E.g. you can access a list of all configured repositories with
+
+----
+$ gem nexus --all-repos
+
+DEFAULT: http://localhost:8081/repository/rubygems-hosted
+----
+
+////
+/* Local Variables: */
+/* ispell-personal-dictionary: "ispell.dict" */
+/* End:             */
+////

--- a/nexus-book-declarations.asciidoc
+++ b/nexus-book-declarations.asciidoc
@@ -14,7 +14,7 @@ The "things" we ship, we do NOT add solutions
 :rhc: Repository Health Check
 
 :version: 3.0.2
-:version-exact: 3.0.2-01
+:version-exact: 3.0.2-02
 
 ////
 Usage under chapters to show in what solutions certain features are available 

--- a/nexus-book-declarations.asciidoc
+++ b/nexus-book-declarations.asciidoc
@@ -13,8 +13,8 @@ The "things" we ship, we do NOT add solutions
 :ds: Sonatype Data Services
 :rhc: Repository Health Check
 
-:version: 3.0.1
-:version-exact: 3.0.1-01
+:version: 3.0.2
+:version-exact: 3.0.2-01
 
 ////
 Usage under chapters to show in what solutions certain features are available 


### PR DESCRIPTION
ADDENDUM: 3.0.2-02, it is!

Ahead of the upcoming 3.0.2 release
JIRA: https://issues.sonatype.org/browse/NEXUS-10660
In addition to the new PyPI & RubyGems chapters, updates include:

* Update *nexus-book-declarations* file; replace version-exact 3.0.1-01 with 3.0.2-01 (or whatever the correct one will be)
* Update dependency declarations for *nexus-book-examples* repo in the 3.x branch (mainly in the scripting section)
* Check book for any necessary updates per patches/fixes to be shipped with the 3.0.2 release
* Update Compatibility Matrix - https://support.sonatype.com/hc/en-us/articles/222426568-Nexus-Repository-Manager-Feature-Compatibility-Matrix
* Publish in bamboo