### PR TITLE
Addendum NEXUS 10425 nginx master patch

### DIFF
--- a/chapter-installation.asciidoc
+++ b/chapter-installation.asciidoc
@@ -653,10 +653,10 @@ http {
         server_name  www.example.com;
 
         # allow large uploads of files - refer to nginx documentation
-        client_max_body_size 1G
+        client_max_body_size 1G;
 
         # optimize downloading files larger than 1G - refer to nginx doc before adjusting
-        #proxy_max_temp_file_size 2G
+        #proxy_max_temp_file_size 2G;
 
         location /nexus {
             proxy_pass http://localhost:8081/nexus;
@@ -710,10 +710,10 @@ http {
         server_name  repo.example.com;
 
         # allow large uploads of files - refer to nginx documentation
-        client_max_body_size 1G
+        client_max_body_size 1G;
 
         # optimize downloading files larger than 1G - refer to nginx doc before adjusting
-        #proxy_max_temp_file_size 2G
+        #proxy_max_temp_file_size 2G;
 
         location / {
             proxy_pass http://localhost:8081/;
@@ -785,10 +785,10 @@ http {
         server_name  repo.example.com;
 
         # allow large uploads of files - refer to nginx documentation
-        client_max_body_size 1G
+        client_max_body_size 1G;
 
         # optimize downloading files larger than 1G - refer to nginx doc before adjusting
-        #proxy_max_temp_file_size 2G
+        #proxy_max_temp_file_size 2G;
 
         ssl on
         ssl_certificate      example.pem;

--- a/chapter-installation.asciidoc
+++ b/chapter-installation.asciidoc
@@ -790,7 +790,7 @@ http {
         # optimize downloading files larger than 1G - refer to nginx doc before adjusting
         #proxy_max_temp_file_size 2G;
 
-        ssl on
+        ssl on;
         ssl_certificate      example.pem;
         ssl_certificate_key  example.key;
 


### PR DESCRIPTION
Addendum to the work in JIRA: https://issues.sonatype.org/browse/NEXUS-10425

Updated nginx.conf example files with correct punctuation. Basically each directive
should end with a semicolon, even if commented out.