### PR TITLE
NEXUS-10284-limiting-search-results

### DIFF
--- a/chapter-using-nexus-ui.asciidoc
+++ b/chapter-using-nexus-ui.asciidoc
@@ -232,8 +232,8 @@ pattern.
 
 Once you have provided your search terms in one or multiple criteria input fields, like the 'Keywords' criteria 
 in the 'Search' feature view, the first 1000 results become visible in the component list, with an example 
-displayed  in <<fig-search-results>>. If more than 1000 results are displayed, notation will appear under the 
-filters relaying how many items were found in total.
+displayed  in <<fig-search-results>>. If more than 1000 results exist, notation will appear under the filters 
+relaying how many items were found in total.
 
 The components are listed with their 'Name', 'Group', 'Version', 'Format', 'Repository', 'Age' and 'Popularity' 
 information and are sorted alphabetically by 'Name'.  Columns and sort order can be adjusted like in all other 
@@ -254,7 +254,6 @@ a good idea on the adoption rate of a new release. For example if a newer versio
 popularity compared to an older version, you might want to check the upstream project and see if there is any
 issues stopping other users from upgrading that might affect you as well. Another reason could be that the new
 version does not provide significant improvements to warrant an upgrade for most users.
-
 
 Selecting a component in the list changes to a display of the component information documented in
 <<component-information>>.

--- a/chapter-using-nexus-ui.asciidoc
+++ b/chapter-using-nexus-ui.asciidoc
@@ -230,11 +230,14 @@ pattern.
 
 ==== Search Results
 
-Once you have provided your search terms in one or multiple criteria input fields, like the 'Keywords' criteria in
-the 'Search' feature view, the results become visible in the component list, with an example displayed in
-<<fig-search-results>>. The components are listed with their 'Name', 'Group', 'Version', 'Format', 'Repository',
-'Age' and 'Popularity' information and are sorted alphabetically by 'Name'.  Columns and sort order can be
-adjusted like in all other lists.
+Once you have provided your search terms in one or multiple criteria input fields, like the 'Keywords' criteria 
+in the 'Search' feature view, the first 1000 results become visible in the component list, with an example 
+displayed  in <<fig-search-results>>. If more than 1000 results are displayed, notation will appear under the 
+filters relaying how many items were found in total.
+
+The components are listed with their 'Name', 'Group', 'Version', 'Format', 'Repository', 'Age' and 'Popularity' 
+information and are sorted alphabetically by 'Name'.  Columns and sort order can be adjusted like in all other 
+lists.
 
 [[fig-search-results]]
 .Results of a Component Search for +junit+


### PR DESCRIPTION
In https://issues.sonatype.org/browse/NEXUS-10284 we limited the number of search results.  Updating documentation to match.
Also 114ized a line above the one I was changing=)