### PR TITLE
[NEXUS 10676] ruby-upgrade

### DIFF
--- a/chapter-upgrading.asciidoc
+++ b/chapter-upgrading.asciidoc
@@ -142,9 +142,8 @@ represents repository formats that can included in the upgrade process.
 * NuGet
 * Site/Raw
 * Maven2
-////
 * RubyGems
-////
+
 
 [[upgrade-prep]]
 ==== Designing Your Upgrade Plan
@@ -312,8 +311,6 @@ Staging rules:: If you are a {pro} user that uses the application for staging re
 number of configured rules.
 Scheduled task for releases:: If you find empty 'Use Index' checkboxes under 'Task Settings', use the opportunity
 to disable or remove those specific tasks for releases.
-Smart Proxy Preemptive Fetch:: The most notable performance benefit is that hidden caches are utilized more
-efficiently.
 
 ////
 * Reviewing the Custom Metadata capability (when enabled)

--- a/chapter-upgrading.asciidoc
+++ b/chapter-upgrading.asciidoc
@@ -311,6 +311,8 @@ Staging rules:: If you are a {pro} user that uses the application for staging re
 number of configured rules.
 Scheduled task for releases:: If you find empty 'Use Index' checkboxes under 'Task Settings', use the opportunity
 to disable or remove those specific tasks for releases.
+Smart Proxy Preemptive Fetch:: The most notable performance benefit is that hidden caches are utilized more		
+efficiently.
 
 ////
 * Reviewing the Custom Metadata capability (when enabled)


### PR DESCRIPTION
Uncommented RubyGems as an upgradeable format.

Addendum: Additional fix was removed per https://github.com/sonatype/nexus-book/pull/231#issuecomment-247300583. (Will update in another version or directly from the trunk.)