### PR TITLE
Scripting - Fix Typo in Sample pom.xml

### DIFF
--- a/chapter-scripting.asciidoc
+++ b/chapter-scripting.asciidoc
@@ -37,7 +37,7 @@ available in the https://github.com/sonatype/nexus-book-examples/tree/nexus-3.0.
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <nx.version>3.0.0-03</nx.version>
+    <nx-version>3.0.0-03</nx-version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
In the sample `pom.xml` file the `nx.version` property is defined with a period, but referenced as `nx-version`. Make them consistent so the sample `pom.xml` file works without any modifications.

The master branch appeared to still be Nexus Book version 2. If this needs to be applied to a different branch, let me know.